### PR TITLE
добавляет типизацию для использования в сторонних проектах

### DIFF
--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
     "stylelint-prettier": "^1.1.1",
     "svgo": "^1.3.0",
     "ts-essentials": "^3.0.0",
-    "typescript": "^3.5.3"
+    "typescript": "^3.7.3"
   },
   "homepage": "https://gpn-prototypes.github.io/ui-kit",
   "jest": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "declaration": false,
+    "declaration": true,
     "noImplicitAny": false,
     "outDir": "./dist",
     "target": "es5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14237,10 +14237,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^3.5.3:
-  version "3.6.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.6.4.tgz#b18752bb3792bc1a0281335f7f6ebf1bbfc5b91d"
-  integrity sha512-unoCll1+l+YK4i4F8f22TaNVPRHcD9PA3yCuZ8g5e0qGqlVlJ/8FSateOLLSagn+Yg5+ZwuPkL8LFUc0Jcvksg==
+typescript@^3.7.3:
+  version "3.7.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.3.tgz#b36840668a16458a7025b9eabfad11b66ab85c69"
+  integrity sha512-Mcr/Qk7hXqFBXMN7p7Lusj1ktCBydylfQM/FZCk5glCNQJrCUKPkMHdo9R0MTFWsC/4kPFvDS0fDPvukfCkFsw==
 
 ua-parser-js@^0.7.18:
   version "0.7.20"


### PR DESCRIPTION
Добавил генерацию типов - теперь в библиотеке есть удобный автокомплит импортов, их свойств, ну и не надо заниматься дублированием деклараций в каждом из проектов, куда импортится ui-kit.

Подъем версии TS обеспечивает совместную работу опций declaration и allowJs/isolatedModules.