### PR TITLE
Заменить тег обёртки компонента Icon

### DIFF
--- a/src/icons/Icon/Icon.tsx
+++ b/src/icons/Icon/Icon.tsx
@@ -35,8 +35,8 @@ export const Icon: React.FC<IIcon> = ({
   ...otherProps
 }) => {
   return (
-    <div {...otherProps} className={cnIcon({ size, view }, [className])} ref={innerRef}>
+    <span {...otherProps} className={cnIcon({ size, view }, [className])} ref={innerRef}>
       {children}
-    </div>
+    </span>
   );
 };


### PR DESCRIPTION
## Проблема
Сейчас для обёртки используется тэг `div`, что приводит к тому что внутри кнопок, строчных элементов размещается `div`.

Данный фикс заменяет `div` на `span`