### PR TITLE
fix(SnackBar-Timer): fixed bugs related to infinite component rendering

### DIFF
--- a/src/components/SnackBar/Item/SnackBar-Item.tsx
+++ b/src/components/SnackBar/Item/SnackBar-Item.tsx
@@ -15,7 +15,7 @@ export type SnackBarItemProps = {
   item: Item;
 };
 
-const defaultInitialTimerTime = 3000;
+const defaultInitialTimerTime = 3;
 
 const getAutoCloseTime = (autoClose: boolean | number | undefined): number | false => {
   if (autoClose) {
@@ -74,7 +74,11 @@ export const SnackBarItem: React.FC<SnackBarItemProps> = (props) => {
       )}
       {!autoCloseTime && Icon && <Icon className={cnSnackBar('Icon')} size="m" />}
       <div className={cnSnackBar('Content')}>
-        {message && <Text lineHeight="s">{message}</Text>}
+        {message && (
+          <Text className={cnSnackBar('Message')} lineHeight="s">
+            {message}
+          </Text>
+        )}
         {actions && <SnackBarActionButton actions={actions} />}
       </div>
       {onClose && (

--- a/src/components/SnackBar/SnackBar.test.tsx
+++ b/src/components/SnackBar/SnackBar.test.tsx
@@ -1,0 +1,221 @@
+import * as React from 'react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+
+import { cnIcon } from '../../icons/Icon/Icon';
+import { IconAdd } from '../../icons/IconAdd/IconAdd';
+
+import { cnSnackBar, SnackBar } from './SnackBar';
+
+type SnackBarProps = React.ComponentProps<typeof SnackBar>;
+
+const testId = cnSnackBar();
+
+const items: SnackBarProps['items'] = [
+  {
+    key: 1,
+  },
+];
+
+const renderComponent = (props: SnackBarProps = { items }) => {
+  return render(<SnackBar data-testid={testId} {...props} />);
+};
+
+describe('Компонент SnackBar', () => {
+  it('должен рендериться без ошибок', () => {
+    expect(renderComponent).not.toThrow();
+  });
+  describe('проверка items', () => {
+    describe('массив рендерится верно', () => {
+      it(`количество совпадает с передоваемым`, () => {
+        const items: SnackBarProps['items'] = [
+          {
+            key: 1,
+          },
+          {
+            key: 2,
+          },
+          {
+            key: 3,
+          },
+        ];
+
+        renderComponent({ items });
+
+        const snackBar = screen.getByTestId(testId);
+        const itemsRender = snackBar.querySelectorAll(`.${cnSnackBar('Item')}`);
+        expect(itemsRender.length).toEqual(items.length);
+      });
+    });
+    describe('проверка message', () => {
+      it(`отображает текст сообщения `, () => {
+        const messageText = 'Сообщение';
+        const items: SnackBarProps['items'] = [
+          {
+            key: 1,
+            message: messageText,
+          },
+        ];
+
+        renderComponent({ items });
+
+        const snackBar = screen.getByTestId(testId);
+        const message = snackBar.querySelector(`.${cnSnackBar('Message')}`) as HTMLDivElement;
+
+        expect(message.textContent).toEqual(messageText);
+      });
+    });
+    describe('проверка status', () => {
+      const statuses = ['system', 'success', 'warning', 'alert', 'normal'] as const;
+      statuses.forEach((status) => {
+        it(`присваивает класс для status=${status} `, () => {
+          const items: SnackBarProps['items'] = [
+            {
+              key: 1,
+              status,
+            },
+          ];
+
+          renderComponent({ items });
+
+          const snackBar = screen.getByTestId(testId);
+          const item = snackBar.querySelector(`.${cnSnackBar('Item')}`) as HTMLDivElement;
+
+          expect(item).toHaveClass(cnSnackBar('Item', { status }));
+        });
+      });
+    });
+    describe('проверка icon', () => {
+      it('отображает иконку', () => {
+        const items: SnackBarProps['items'] = [
+          {
+            key: 1,
+            icon: IconAdd,
+          },
+        ];
+
+        renderComponent({ items });
+
+        const snackBar = screen.getByTestId(testId);
+        const icon = snackBar.querySelector(`.${cnSnackBar('Icon')}`) as HTMLSpanElement;
+
+        expect(icon).toHaveClass(cnIcon());
+      });
+    });
+    describe('проверка actions', () => {
+      const actionLabel = 'Действие';
+      const handleClick = jest.fn();
+      const items: SnackBarProps['items'] = [
+        {
+          key: 1,
+          actions: [
+            {
+              label: actionLabel,
+              onClick: handleClick,
+            },
+          ],
+        },
+      ];
+      it('отображает кнопку действия', () => {
+        renderComponent({ items });
+
+        const snackBar = screen.getByTestId(testId);
+        const actionButton = snackBar.querySelector(
+          `.${cnSnackBar('ActionButton')}`,
+        ) as HTMLButtonElement;
+
+        expect(actionButton.textContent).toEqual(actionLabel);
+      });
+      it('кнопка действия срабатывает', () => {
+        renderComponent({ items });
+
+        const snackBar = screen.getByTestId(testId);
+        const actionButton = snackBar.querySelector(
+          `.${cnSnackBar('ActionButton')}`,
+        ) as HTMLButtonElement;
+
+        fireEvent.click(actionButton);
+
+        expect(handleClick).toHaveBeenCalledTimes(1);
+      });
+    });
+    describe('проверка onClose', () => {
+      const handleClick = jest.fn();
+      const items: SnackBarProps['items'] = [
+        {
+          key: 1,
+          onClose: handleClick,
+        },
+      ];
+      it('отображает иконку на кнопке', () => {
+        renderComponent({ items });
+
+        const snackBar = screen.getByTestId(testId);
+        const closeButton = snackBar.querySelector(
+          `.${cnSnackBar('CloseButton')}`,
+        ) as HTMLSpanElement;
+
+        expect(closeButton.children[0]).toHaveClass(cnIcon());
+      });
+      it('кнопка закрытия срабатывает', () => {
+        renderComponent({ items });
+
+        const snackBar = screen.getByTestId(testId);
+        const closeButton = snackBar.querySelector(
+          `.${cnSnackBar('CloseButton')}`,
+        ) as HTMLSpanElement;
+
+        fireEvent.click(closeButton);
+
+        expect(handleClick).toHaveBeenCalledTimes(1);
+      });
+    });
+    describe('проверка autoClose', () => {
+      it('срабатывает действие при autoClose = 1', () => {
+        const handleClick = jest.fn();
+        const items: SnackBarProps['items'] = [
+          {
+            key: 1,
+            autoClose: 1,
+            onClose: handleClick,
+          },
+        ];
+
+        jest.useFakeTimers();
+        act(() => {
+          renderComponent({ items });
+        });
+
+        expect(handleClick).not.toBeCalled();
+        act(() => {
+          jest.advanceTimersByTime(1000);
+        });
+
+        expect(handleClick).toBeCalled();
+        expect(handleClick).toHaveBeenCalledTimes(1);
+      });
+      it('срабатывает действие при autoClose = true', () => {
+        const handleClick = jest.fn();
+        const items: SnackBarProps['items'] = [
+          {
+            key: 1,
+            autoClose: true,
+            onClose: handleClick,
+          },
+        ];
+
+        jest.useFakeTimers();
+        act(() => {
+          renderComponent({ items });
+        });
+
+        expect(handleClick).not.toBeCalled();
+        act(() => {
+          jest.advanceTimersByTime(3000);
+        });
+
+        expect(handleClick).toBeCalled();
+        expect(handleClick).toHaveBeenCalledTimes(1);
+      });
+    });
+  });
+});

--- a/src/components/SnackBar/Timer/SnackBar-Timer.tsx
+++ b/src/components/SnackBar/Timer/SnackBar-Timer.tsx
@@ -30,7 +30,7 @@ export const SnackBarTimer: React.FC<SnackBarTimerProps> = (props) => {
   useEffect(() => {
     onMount({ start, pause });
     start();
-  }, [onMount, pause, start]);
+  }, []);
 
   useEffect(() => {
     setRunning(isRunning);


### PR DESCRIPTION
## Описание изменений
Исправлены ошибки бесконечного рендера тамера
Исправленна ошибка невозможности сменить состояние тамера после того как он был удален из виртуладом, Изменен Api хука useTimer на более стабильный. Теперь `timeIsOver` не колбеком при инициализации таймера, а не посредственно в значениях хука 

closes #187  

## Чек-лист

- [x] PR: направлен в правильную ветку
- [x] PR: назначен исполнитель PR и указаны нужные лейблы
- [x] PR: проверен diff, ничего лишнего в PR не попало
- [x] PR: прилинкованы затронутые issue и связанные PR
- [x] PR: есть описание изменений
- [x] JS: нет варнингов и ошибок в консоли браузера
- [x] Тесты: новый функционал и исправленные баги покрыты тестами
- [ ] Документация: отражены все изменения в API компонентов и описаны важные особенности реализации или использования
- [ ] Сторибук: для компонентов написаны или обновлены stories
- [ ] Верстка: используются [переменные](../src/components/Theme)
- [ ] Верстка: проверена с разным количеством контента

## Опционально

- [ ] Доработки: заведены задачи для дальнейшей работы, если что-то решено не править в текущем пулл-реквесте
- [x] Коммиты: проименованы в соответствии с [правилами](../docs/commits-style.md)
