### PR TITLE
Feat/185 ban children

### DIFF
--- a/src/components/Attach/Attach.tsx
+++ b/src/components/Attach/Attach.tsx
@@ -22,6 +22,7 @@ type Props = {
   buttonTitle?: string;
   withAction?: boolean;
   className?: string;
+  children?: never;
 };
 
 export const cnAttach = cn('Attach');

--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -14,6 +14,7 @@ type Props = {
   name?: string;
   size?: AvatarPropSize;
   form?: AvatarPropForm;
+  children?: never;
 };
 
 export const cnAvatar = cn('Avatar');

--- a/src/components/Badge/Badge.tsx
+++ b/src/components/Badge/Badge.tsx
@@ -17,6 +17,7 @@ type Props = {
   minified?: boolean;
   icon?: React.FC<IconProps>;
   label?: string;
+  children?: never;
 };
 
 export const cnBadge = cn('Badge');

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -34,6 +34,7 @@ type Props = {
   onlyIcon?: boolean;
   iconSize?: IconPropSize;
   title?: string;
+  children?: never;
 };
 
 export const cnButton = cn('Button');

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -28,6 +28,7 @@ type Props = {
   step?: number | string;
   tabIndex?: number;
   inputRef?: React.Ref<HTMLInputElement>;
+  children?: never;
 };
 
 export type CheckboxProps = PropsWithHTMLAttributes<Props, HTMLLabelElement>;

--- a/src/components/ChoiceGroup/ChoiceGroup.tsx
+++ b/src/components/ChoiceGroup/ChoiceGroup.tsx
@@ -23,6 +23,7 @@ type Props<T> = {
   onlyIcon?: boolean;
   getItemIcon?: (item: T) => React.FC<IconProps> | undefined;
   getItemTitle?: BaseCheckGroupFieldPropGetItemLabel<T>;
+  children?: never;
 };
 
 export type ChoiceGroupProps<T> = Props<T> &

--- a/src/components/File/File.tsx
+++ b/src/components/File/File.tsx
@@ -33,6 +33,7 @@ type Props = {
   loading?: boolean;
   loadingWithProgressSpin?: boolean;
   loadingProgress?: number;
+  children?: never;
 };
 
 export type FileProps = Props & Omit<FileIconProps, keyof Props>;
@@ -69,7 +70,7 @@ export const File: React.FC<FileProps> = (props) => {
     );
   }
 
-  const extensionToSvg: { [value: string]: React.FC<FileProps> } = {
+  const extensionToSvg: { [value: string]: React.FC<FileIconProps> } = {
     bmp: FileIconBmp,
     csv: FileIconCsv,
     avi: FileIconAvi,

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -8,6 +8,7 @@ export type HeaderProps = {
   leftSide?: React.ReactNode;
   rightSide?: React.ReactNode;
   className?: string;
+  children?: never;
 };
 
 export const cnHeader = cn('Header');

--- a/src/components/Header/Login/Header-Login.tsx
+++ b/src/components/Header/Login/Header-Login.tsx
@@ -13,6 +13,7 @@ type Props = {
   personAvatarUrl?: string;
   isMinified?: boolean;
   className?: string;
+  children?: never;
 };
 
 export const HeaderLogin: React.FC<Props> = ({

--- a/src/components/Header/Menu/Header-Menu.tsx
+++ b/src/components/Header/Menu/Header-Menu.tsx
@@ -11,6 +11,7 @@ export type Item = {
   target?: string;
   active?: boolean;
   onClick?: React.EventHandler<React.MouseEvent>;
+  children?: never;
 };
 
 type Props = {

--- a/src/components/Header/SearchBar/Header-SearchBar.tsx
+++ b/src/components/Header/SearchBar/Header-SearchBar.tsx
@@ -22,6 +22,7 @@ type SearchBarProps = {
   value?: SearchBarPropValue;
   onSearch?: SearchBarPropOnSearch;
   onChange?: SearchBarPropOnChange;
+  children?: never;
 };
 
 export const HeaderSearchBar: React.FC<SearchBarProps> = ({

--- a/src/components/Informer/Informer.tsx
+++ b/src/components/Informer/Informer.tsx
@@ -17,7 +17,6 @@ type Props = {
   status?: InformerPropStatus;
   icon?: React.FC<IconProps>;
   label?: React.ReactNode;
-  children?: React.ReactNode;
   title?: string;
 };
 

--- a/src/components/Loader/Loader.tsx
+++ b/src/components/Loader/Loader.tsx
@@ -9,6 +9,7 @@ export type LoaderPropSize = 's' | 'm';
 
 type Props = {
   size?: LoaderPropSize;
+  children?: never;
 };
 
 export type LoaderProps = PropsWithHTMLAttributes<Props, HTMLDivElement>;

--- a/src/components/ProgressSpin/ProgressSpin.tsx
+++ b/src/components/ProgressSpin/ProgressSpin.tsx
@@ -11,6 +11,7 @@ type Props = {
   className?: string;
   progress?: number;
   animation?: boolean;
+  children?: never;
 };
 export type ProgressSpinProps = PropsWithHTMLAttributes<Props, SVGElement>;
 

--- a/src/components/Radio/Radio.tsx
+++ b/src/components/Radio/Radio.tsx
@@ -29,6 +29,7 @@ export type Props = {
   step?: number | string;
   tabIndex?: number;
   inputRef?: React.Ref<HTMLInputElement>;
+  children?: never;
 };
 
 export type RadioProps = PropsWithHTMLAttributes<Props, HTMLLabelElement>;

--- a/src/components/SnackBar/SnackBar.tsx
+++ b/src/components/SnackBar/SnackBar.tsx
@@ -29,6 +29,7 @@ export type Item = {
 
 type Props = {
   items: Item[];
+  children?: never;
 };
 
 export type SnackBarProps = PropsWithHTMLAttributes<Props, HTMLDivElement>;

--- a/src/components/Switch/Switch.tsx
+++ b/src/components/Switch/Switch.tsx
@@ -28,6 +28,7 @@ type Props = {
   step?: number | string;
   tabIndex?: number;
   inputRef?: React.Ref<HTMLInputElement>;
+  children?: never;
 };
 
 export type SwitchProps = PropsWithHTMLAttributes<Props, HTMLLabelElement>;

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -20,6 +20,7 @@ type Props<T> = {
   onlyIcon?: boolean;
   view?: TabsPropView;
   getItemIcon?: (item: T) => React.FC<IconProps> | undefined;
+  children?: never;
 };
 export type TabsProps<T> = Props<T> &
   Omit<BaseCheckGroupFieldProps<T>, 'componentItem' | 'getAdditionalPropsForItem' | 'multiple'>;

--- a/src/components/Text/Text.tsx
+++ b/src/components/Text/Text.tsx
@@ -54,7 +54,6 @@ type Props = {
   view?: TextPropView;
   weight?: TextPropWeight;
   width?: TextPropWidth;
-  children?: React.ReactNode;
 };
 
 export const cnText = cn('Text');

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -70,6 +70,7 @@ type Props = {
   tabIndex?: number;
   inputRef?: React.Ref<HTMLTextAreaElement | HTMLInputElement>;
   ariaLabel?: string;
+  children?: never;
 };
 
 export type TextFieldProps = PropsWithHTMLAttributes<Props, HTMLDivElement>;

--- a/src/components/Timer/Timer.tsx
+++ b/src/components/Timer/Timer.tsx
@@ -13,6 +13,7 @@ type Props = {
   seconds?: number;
   progress?: number;
   animation?: boolean;
+  children?: never;
 };
 
 export type TimerProps = PropsWithHTMLAttributes<Props, HTMLDivElement>;

--- a/src/components/User/User.tsx
+++ b/src/components/User/User.tsx
@@ -24,6 +24,7 @@ type Props = {
   onlyAvatar?: boolean;
   withArrow?: boolean;
   info?: string;
+  children?: never;
 };
 
 const cnUser = cn('User');


### PR DESCRIPTION
BREAKING CHANGE:
interface change in components

closes  #185

## Описание изменений
Запретил передавать children в компоненты, которые их не используют

## Чек-лист

- [x] PR: направлен в правильную ветку
- [x] PR: назначен исполнитель PR и указаны нужные лейблы
- [x] PR: проверен diff, ничего лишнего в PR не попало
- [x] PR: прилинкованы затронутые issue и связанные PR
- [x] PR: есть описание изменений
- [x] JS: нет варнингов и ошибок в консоли браузера
- [ ] Тесты: новый функционал и исправленные баги покрыты тестами
- [ ] Документация: отражены все изменения в API компонентов и описаны важные особенности реализации или использования
- [ ] Сторибук: для компонентов написаны или обновлены stories
- [ ] Верстка: используются [переменные](../src/components/Theme)
- [ ] Верстка: проверена с разным количеством контента

## Опционально

- [ ] Доработки: заведены задачи для дальнейшей работы, если что-то решено не править в текущем пулл-реквесте
- [ ] Коммиты: проименованы в соответствии с [правилами](../docs/commits-style.md)
