### PR TITLE
fix(ts-ignore): removed ts-ignore

### DIFF
--- a/src/components/Attach/stories/examples/AttachExampleError/AttachExampleError.tsx
+++ b/src/components/Attach/stories/examples/AttachExampleError/AttachExampleError.tsx
@@ -1,9 +1,7 @@
 import './AttachExampleError.css';
 
 import React from 'react';
-// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-// @ts-ignore
-import { Preview } from '@storybook/addon-docs/blocks';
+import { Preview } from '@storybook/addon-docs/dist/blocks';
 
 import { cn } from '../../../../../utils/bem';
 import { presetGpnDefault, Theme } from '../../../../Theme/Theme';

--- a/src/components/Attach/stories/examples/AttachExampleEvents/AttachExampleEvents.tsx
+++ b/src/components/Attach/stories/examples/AttachExampleEvents/AttachExampleEvents.tsx
@@ -1,9 +1,7 @@
 import './AttachExampleEvents.css';
 
 import React from 'react';
-// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-// @ts-ignore
-import { Preview } from '@storybook/addon-docs/blocks';
+import { Preview } from '@storybook/addon-docs/dist/blocks';
 
 import { IconTrash } from '../../../../../icons/IconTrash/IconTrash';
 import { cn } from '../../../../../utils/bem';

--- a/src/components/Attach/stories/examples/AttachExampleLoading/AttachExampleLoading.tsx
+++ b/src/components/Attach/stories/examples/AttachExampleLoading/AttachExampleLoading.tsx
@@ -1,9 +1,7 @@
 import './AttachExampleLoading.css';
 
 import React from 'react';
-// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-// @ts-ignore
-import { Preview } from '@storybook/addon-docs/blocks';
+import { Preview } from '@storybook/addon-docs/dist/blocks';
 
 import { cn } from '../../../../../utils/bem';
 import { presetGpnDefault, Theme } from '../../../../Theme/Theme';

--- a/src/hooks/useClickOutside.ts
+++ b/src/hooks/useClickOutside.ts
@@ -5,8 +5,6 @@ export const useClickOutside = (): [boolean, Dispatch<SetStateAction<boolean>>] 
 
   const onClose = () => setOpened(false);
 
-  // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-  // @ts-ignore
   useEffect(() => {
     if (isOpened) {
       window.addEventListener('click', onClose);
@@ -15,6 +13,7 @@ export const useClickOutside = (): [boolean, Dispatch<SetStateAction<boolean>>] 
         window.removeEventListener('click', onClose);
       };
     }
+    return undefined;
   }, [isOpened]);
 
   return [isOpened, setOpened];

--- a/src/utils/setRef.ts
+++ b/src/utils/setRef.ts
@@ -1,14 +1,11 @@
 import * as React from 'react';
 
-export function setRef<T>(
-  ref: React.RefObject<T> | ((instance: T | null) => void) | null | undefined,
-  value: T | null,
-): void {
+type Ref<T> = React.RefCallback<T> | React.MutableRefObject<T> | undefined;
+
+export function setRef<T>(ref: Ref<T>, value: T): void {
   if (typeof ref === 'function') {
     ref(value);
   } else if (ref) {
-    // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-    // @ts-ignore
     // eslint-disable-next-line no-param-reassign
     ref.current = value;
   }

--- a/src/utils/useForkRef.ts
+++ b/src/utils/useForkRef.ts
@@ -2,16 +2,17 @@ import * as React from 'react';
 
 import { setRef } from './setRef';
 
-type Ref<T> = React.Ref<T> | undefined;
+type AtributesRef<T> = React.Ref<T> | undefined;
+type ResultRef<T> = React.RefCallback<T> | null;
 
-export function useForkRef<T>(refs: Ref<T>[]): React.Ref<T> {
+export function useForkRef<T>(refs: AtributesRef<T>[]): ResultRef<T> {
   return React.useMemo(() => {
     if (refs.length < 1) {
       return null;
     }
     return (refValue) => {
       for (const ref of refs) {
-        setRef(ref, refValue);
+        setRef(ref as React.MutableRefObject<T>, refValue);
       }
     };
   }, [refs]);


### PR DESCRIPTION
closes #210

## Описание изменений
Убрал игноры где было возможно остались 
- в старом Select,
- в setRef, `ref.current = value;` = ref.current - доступен только для чтения, но нам нужно иметь возможность засетить реф, сейчас используется когда нужно указать более одной ссылки на один DOM елемент.

## Чек-лист

- [x] PR: направлен в правильную ветку
- [x] PR: назначен исполнитель PR и указаны нужные лейблы
- [x] PR: проверен diff, ничего лишнего в PR не попало
- [x] PR: прилинкованы затронутые issue и связанные PR
- [x] PR: есть описание изменений
- [x] JS: нет варнингов и ошибок в консоли браузера
- [ ] Тесты: новый функционал и исправленные баги покрыты тестами
- [ ] Документация: отражены все изменения в API компонентов и описаны важные особенности реализации или использования
- [ ] Сторибук: для компонентов написаны или обновлены stories
- [ ] Верстка: используются [переменные](../src/components/Theme)
- [ ] Верстка: проверена с разным количеством контента

## Опционально

- [ ] Доработки: заведены задачи для дальнейшей работы, если что-то решено не править в текущем пулл-реквесте
- [ ] Коммиты: проименованы в соответствии с [правилами](../docs/commits-style.md)
