### PR TITLE
feat(Tag): add component Tag

### DIFF
--- a/build.config.js
+++ b/build.config.js
@@ -13,6 +13,7 @@ module.exports = {
     'src/components/ScrollExample/**',
     'src/components/ThemePreview/**',
     'src/components/ThemePreview/**',
+    'src/components/TagBase/**',
     'src/components/BaseCheckGroupField/**',
     'src/icons/BaseIconHoc/**',
     'src/fileIcons/BaseFileIconHoc/**',

--- a/src/components/Tag/Tag.css
+++ b/src/components/Tag/Tag.css
@@ -1,0 +1,16 @@
+.TagBase.Tag {
+  &_mode {
+    &_cancel {
+      cursor: auto;
+
+      &:hover {
+        --bg-color: var(--color-control-bg-ghost);
+      }
+    }
+
+    &_link {
+      text-decoration: none;
+      cursor: pointer;
+    }
+  }
+}

--- a/src/components/Tag/Tag.test.tsx
+++ b/src/components/Tag/Tag.test.tsx
@@ -1,0 +1,112 @@
+import * as React from 'react';
+import { render, screen } from '@testing-library/react';
+
+import { cnTag, getParams, Tag } from './Tag';
+
+type TagProps = React.ComponentProps<typeof Tag>;
+
+const testId = cnTag();
+
+const renderComponent = (props: TagProps) => {
+  return render(<Tag data-testid={testId} {...props} />);
+};
+
+describe('Компонент Tag', () => {
+  it('должен рендериться без ошибок', () => {
+    expect(renderComponent).not.toThrow();
+  });
+
+  describe('проверка props', () => {
+    const label = 'label';
+    describe('проверка mode', () => {
+      const modes = ['button', 'link', 'check', 'cancel'] as const;
+
+      const handleClick = jest.fn();
+
+      modes.forEach((mode) => {
+        it(`присваивает класс для mode=${mode}`, () => {
+          switch (mode) {
+            case 'check':
+              renderComponent({ label, mode, checked: true, onChange: handleClick });
+              break;
+            case 'button':
+              renderComponent({ label, mode, onClick: handleClick });
+              break;
+            case 'link':
+              renderComponent({ label, mode });
+              break;
+            case 'cancel':
+              renderComponent({ label, mode, onCancel: handleClick });
+              break;
+          }
+
+          const tag = screen.getByTestId(testId);
+
+          expect(tag).toHaveClass(cnTag({ mode }));
+        });
+      });
+    });
+    describe('проверка className', () => {
+      const className = 'className';
+
+      it(`присваивает className`, () => {
+        renderComponent({ label, className, mode: 'link' });
+
+        const tagBase = screen.getByTestId(testId);
+
+        expect(tagBase).toHaveClass(className);
+      });
+    });
+  });
+  describe('проверка getParams', () => {
+    const modes = ['button', 'link', 'check', 'cancel'] as const;
+    const onClick = jest.fn();
+    const onChange = undefined;
+    const onCancel = jest.fn();
+    const checked = true;
+
+    const testModeButton = {
+      view: 'filled',
+      onClick,
+      as: 'button',
+    };
+
+    const testModeLink = {
+      view: 'filled',
+      onClick,
+      as: 'a',
+    };
+
+    const testModeCheck = {
+      view: checked ? 'filled' : 'stroked',
+      onClick: undefined,
+      as: 'button',
+    };
+
+    const testModeCancel = {
+      view: 'filled',
+      onCancel,
+      as: 'div',
+    };
+
+    modes.forEach((mode) => {
+      it(`возвращает верный обьект при mode=${mode}`, () => {
+        const params = getParams(mode, checked, onClick, onChange, onCancel);
+
+        switch (mode) {
+          case 'check':
+            expect(params).toEqual(testModeCheck);
+            return;
+          case 'button':
+            expect(params).toEqual(testModeButton);
+            return;
+          case 'link':
+            expect(params).toEqual(testModeLink);
+            return;
+          case 'cancel':
+            expect(params).toEqual(testModeCancel);
+        }
+      });
+    });
+  });
+});

--- a/src/components/Tag/Tag.tsx
+++ b/src/components/Tag/Tag.tsx
@@ -1,0 +1,127 @@
+import './Tag.css';
+
+import React from 'react';
+
+import { IconProps } from '../../icons/Icon/Icon';
+import { cn } from '../../utils/bem';
+import { TagBase } from '../TagBase/TagBase';
+
+type TagBaseProps = React.ComponentProps<typeof TagBase>;
+
+type TagPropMode = 'check' | 'button' | 'cancel' | 'link';
+
+type CommonProps = {
+  size?: TagBaseProps['size'];
+  label: TagBaseProps['label'];
+  group?: TagBaseProps['group'];
+  icon?: React.FC<IconProps>;
+  iconSize?: IconProps['size'];
+  children?: never;
+};
+
+type PropsWithModeButton = CommonProps & {
+  mode: 'button';
+  onClick: React.MouseEventHandler<HTMLButtonElement>;
+  checked?: never;
+  onChange?: never;
+  onCancel?: never;
+};
+
+type PropsWithModeLink = CommonProps & {
+  mode: 'link';
+  checked?: never;
+  onChange?: never;
+  onCancel?: never;
+};
+
+type PropsWithModeCheck = CommonProps & {
+  mode: 'check';
+  onChange: ({ e, checked }: { e?: React.MouseEvent; checked: boolean }) => void;
+  checked: boolean;
+  onClick?: never;
+  onCancel?: never;
+};
+
+type PropsWithModeCancel = CommonProps & {
+  mode: 'cancel';
+  onCancel: React.MouseEventHandler<HTMLButtonElement>;
+  onClick?: never;
+  onChange?: never;
+  checked?: never;
+};
+
+type Props<ROLE extends TagPropMode = 'button'> = ROLE extends 'button'
+  ? PropsWithModeButton & Omit<JSX.IntrinsicElements['button'], keyof PropsWithModeButton>
+  : {} & ROLE extends 'check'
+  ? PropsWithModeCheck & Omit<JSX.IntrinsicElements['button'], keyof PropsWithModeCheck>
+  : {} & ROLE extends 'cancel'
+  ? PropsWithModeCancel & Omit<JSX.IntrinsicElements['div'], keyof PropsWithModeCancel>
+  : {} & ROLE extends 'link'
+  ? PropsWithModeLink & Omit<JSX.IntrinsicElements['a'], keyof PropsWithModeLink>
+  : {};
+
+type ForwardRefRender<ROLE extends TagPropMode> = (
+  props: Props<ROLE>,
+  ref: React.Ref<HTMLElement>,
+) => React.ReactElement | null;
+
+function forwardRef<ROLE extends TagPropMode>(render: ForwardRefRender<ROLE>) {
+  return React.forwardRef<HTMLElement, Props<ROLE>>(render);
+}
+
+type Component = <ROLE extends TagPropMode>(
+  props: Props<ROLE> & React.RefAttributes<HTMLElement>,
+) => React.ReactElement | null;
+
+export const cnTag = cn('Tag');
+
+export function getParams(
+  mode: TagPropMode,
+  checked?: PropsWithModeCheck['checked'],
+  onClick?: React.MouseEventHandler,
+  onChange?: PropsWithModeCheck['onChange'],
+  onCancel?: PropsWithModeCancel['onCancel'],
+): {
+  view?: TagBaseProps['view'];
+  onClick?: TagBaseProps['onClick'];
+  onCancel?: TagBaseProps['onCancel'];
+  as: keyof JSX.IntrinsicElements;
+} {
+  switch (mode) {
+    case 'button':
+      return {
+        view: 'filled',
+        onClick,
+        as: 'button',
+      };
+    case 'link':
+      return {
+        view: 'filled',
+        onClick,
+        as: 'a',
+      };
+    case 'check':
+      return {
+        view: checked ? 'filled' : 'stroked',
+        onClick:
+          typeof onChange === 'function'
+            ? (e: React.MouseEvent) => onChange({ e, checked: !checked })
+            : undefined,
+        as: 'button',
+      };
+    case 'cancel':
+      return {
+        view: 'filled',
+        onCancel,
+        as: 'div',
+      };
+  }
+}
+
+export const Tag: Component = forwardRef((props, ref) => {
+  const { mode = 'button', className, onChange, checked, onCancel, onClick, ...otherProps } = props;
+
+  const params = getParams(mode, checked, onClick, onChange, onCancel);
+
+  return <TagBase {...otherProps} {...params} ref={ref} className={cnTag({ mode }, [className])} />;
+});

--- a/src/components/Tag/stories/Tag.mdx
+++ b/src/components/Tag/stories/Tag.mdx
@@ -1,0 +1,33 @@
+# Attach
+
+## Пример использования
+
+Использование компонента:
+
+```ts
+// src/App.ts
+import React from 'react';
+import { Tag } from '@gpn-design/uikit/Tag';
+
+const handleClick = () => console.log('click');
+
+const App = () => {
+  return <Tag mode="button" label="Label" onClick={handleClick} />;
+};
+```
+
+## Свойства
+
+| Свойство   | Тип                                                                           | По умолчанию | Описание                                                                 |
+| ---------- | ----------------------------------------------------------------------------- | ------------ | ------------------------------------------------------------------------ |
+| label      | `string`                                                                      | -            | Текст на тэге                                                            |
+| mode       | `'check' , 'button' , 'cancel' ,'link'`                                       | `'button'`   | Режим                                                                    |
+| onClick?   | `React.MouseEventHandler, never`                                              | -            | Событие клика по тэгу. Доступно только при `mode` = `'button'`, `'link'` |
+| onCancel?  | `React.MouseEventHandler, never`                                              | -            | Событие клика по крестику. Доступно только при `mode` = `'cancel'`       |
+| onChange?  | `({ e, checked }: { e?: React.MouseEvent; checked: boolean }) => void, never` | -            | Событие клика по тэгу. Доступно только при `mode` = `'check'`            |
+| checked?   | `boolean, never`                                                              | -            | Пометка выбранного элемента. Доступно только при `mode` = `'check'`      |
+| size?      | `'xs' , 's' , 'm' , 'l'`                                                      | `'m'`        | Размер                                                                   |
+| group?     | `1..9, '1'...'9'`                                                             | -            | Метка группы                                                             |
+| icon?      | `React.FC<IconProps>`                                                         | -            | Иконка                                                                   |
+| className? | `string`                                                                      | -            | Дополнительный класс                                                     |
+| ref?       | `React.Ref<HTMLElement>`                                                      | -            | Ссылка на корневой DOM элемент компонента                                |

--- a/src/components/Tag/stories/Tag.stories.tsx
+++ b/src/components/Tag/stories/Tag.stories.tsx
@@ -1,0 +1,77 @@
+import React, { useState } from 'react';
+import { action } from '@storybook/addon-actions';
+import { boolean, select, text } from '@storybook/addon-knobs';
+
+import { IconAttach } from '../../../icons/IconAttach/IconAttach';
+import { Tag } from '../Tag';
+
+import mdx from './Tag.mdx';
+
+const defaultKnobs = () => ({
+  label: text('label', 'Label'),
+  size: select('size', ['xs', 's', 'm', 'l'], 'm'),
+  mode: select('mode', ['button', 'link', 'check', 'cancel'], 'button'),
+  group: select('group', ['', 1, 2, 3, 4, 5, 6, 7, 8, 9], ''),
+  icon: boolean('icon', false),
+});
+
+export function Playground() {
+  const { label, size, mode, group: groupProp, icon } = defaultKnobs();
+  const [checked, setChecked] = useState<boolean>(false);
+  const group = typeof groupProp === 'number' ? groupProp : undefined;
+  const Icon = icon && IconAttach;
+
+  if (mode === 'check') {
+    return (
+      <Tag
+        mode="check"
+        label={label}
+        size={size}
+        checked={checked}
+        onChange={({ checked }) => setChecked(checked)}
+        group={group}
+        icon={Icon}
+      />
+    );
+  }
+
+  if (mode === 'cancel') {
+    return (
+      <Tag
+        mode="cancel"
+        label={label}
+        size={size}
+        onCancel={action('onCancel')}
+        group={group}
+        icon={Icon}
+      />
+    );
+  }
+
+  if (mode === 'button') {
+    return (
+      <Tag
+        mode="button"
+        label={label}
+        size={size}
+        onClick={action('onClick')}
+        group={group}
+        icon={Icon}
+      />
+    );
+  }
+
+  if (mode === 'link') {
+    return <Tag mode="link" href="#" label={label} size={size} group={group} icon={Icon} />;
+  }
+}
+
+export default {
+  title: 'UI-KIT|/Tag',
+  component: Playground,
+  parameters: {
+    docs: {
+      page: mdx,
+    },
+  },
+};

--- a/src/components/TagBase/TagBase.css
+++ b/src/components/TagBase/TagBase.css
@@ -1,0 +1,168 @@
+.TagBase {
+  --tag-base-typo-color: var(--color-control-typo-ghost);
+  --tag-base-half-space: calc(var(--tag-base-spaсe) / 2);
+  position: relative;
+  display: inline-flex;
+  overflow: hidden;
+  height: var(--tag-base-height);
+  padding-top: 0;
+  padding-right: var(--tag-base-spaсe);
+  padding-left: var(--tag-base-spaсe);
+  padding-bottom: 0;
+  color: var(--tag-base-typo-color);
+  background: var(--tag-base-bg-color);
+  border: none;
+  border-radius: var(--control-radius);
+  box-shadow: inset 0 0 0 1px var(--tag-base-border-color);
+  font-family: var(--font--primary);
+  font-size: var(--tag-base-font-size);
+  line-height: var(--tag-base-height);
+  cursor: pointer;
+  transition: box-shadow 0.15s ease, background 0.15s ease, color 0.15s ease;
+
+  &:focus,
+  &:focus:hover {
+    outline: none;
+  }
+
+  &:hover {
+    --tag-base-typo-color: var(--color-control-typo-ghost-hover);
+  }
+
+  &_view {
+    &_stroked {
+      --tag-base-border-color: var(--color-control-bg-border-default);
+      --tag-base-bg-color: var(--color-bg-default);
+
+      &:hover {
+        --tag-base-border-color: var(--color-control-bg-border-default-hover);
+      }
+    }
+
+    &_filled {
+      --tag-base-border-color: transparent;
+      --tag-base-bg-color: var(--color-control-bg-ghost);
+
+      &:hover {
+        --tag-base-bg-color: var(--color-control-bg-ghost-hover);
+        --tag-base-border-color: transparent;
+      }
+    }
+  }
+
+  &_size {
+    &_xs {
+      --tag-base-height: var(--space-l);
+      --tag-base-spaсe: var(--space-2xs);
+      --tag-base-font-size: var(--size-text-xs);
+    }
+
+    &_s {
+      --tag-base-height: var(--space-xl);
+      --tag-base-spaсe: var(--space-xs);
+      --tag-base-font-size: var(--size-text-xs);
+    }
+
+    &_m {
+      --tag-base-height: calc(var(--space-2xl) - var(--space-2xs));
+      --tag-base-spaсe: var(--space-xs);
+      --tag-base-font-size: var(--size-text-s);
+    }
+
+    &_l {
+      --tag-base-height: var(--space-2xl);
+      --tag-base-spaсe: var(--space-s);
+      --tag-base-font-size: var(--size-text-m);
+    }
+  }
+
+  &_withCancel {
+    padding-right: 0;
+  }
+
+  &_withIcon {
+    padding-left: 0;
+  }
+
+  &[class*='TagBase_group'] {
+    &::before {
+      content: '';
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 2px;
+      height: 100%;
+      background: var(--tag-base-group-color);
+    }
+  }
+
+  &_group {
+    &_1 {
+      --tag-base-group-color: #e92064;
+    }
+
+    &_2 {
+      --tag-base-group-color: #b92eff;
+    }
+
+    &_3 {
+      --tag-base-group-color: #1160ff;
+    }
+
+    &_4 {
+      --tag-base-group-color: #0fafff;
+    }
+
+    &_5 {
+      --tag-base-group-color: #02e2ff;
+    }
+
+    &_6 {
+      --tag-base-group-color: #0c6;
+    }
+
+    &_7 {
+      --tag-base-group-color: #b4d50b;
+    }
+
+    &_8 {
+      --tag-base-group-color: #f5b800;
+    }
+
+    &_9 {
+      --tag-base-group-color: #f56600;
+    }
+  }
+
+  &-CancelButton {
+    display: inline-flex;
+    align-items: center;
+    height: var(--tag-base-height);
+    padding: 0 var(--tag-base-half-space) 0 var(--tag-base-half-space);
+    color: var(--color-control-typo-ghost);
+    background: transparent;
+    border: none;
+    outline: none;
+    opacity: 0.4;
+    cursor: pointer;
+    transition: opacity 0.15s ease;
+
+    &:hover {
+      background: transparent;
+      outline: none;
+      opacity: 1;
+    }
+  }
+
+  &-Label {
+    height: var(--tag-base-height);
+    line-height: var(--tag-base-height);
+  }
+
+  &-IconWrapper {
+    display: inline-flex;
+    align-items: center;
+    height: var(--tag-base-height);
+    padding: 0 var(--tag-base-half-space) 0 var(--tag-base-half-space);
+  }
+}

--- a/src/components/TagBase/TagBase.test.tsx
+++ b/src/components/TagBase/TagBase.test.tsx
@@ -1,0 +1,131 @@
+import * as React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { cnIcon } from '../../icons/Icon/Icon';
+import { IconAttach } from '../../icons/IconAttach/IconAttach';
+
+import { cnTagBase, TagBase } from './TagBase';
+
+type TagBaseProps = React.ComponentProps<typeof TagBase>;
+
+const testId = cnTagBase();
+
+const renderComponent = (props: TagBaseProps) => {
+  return render(<TagBase data-testid={testId} {...props} />);
+};
+
+describe('Компонент TagBase', () => {
+  it('должен рендериться без ошибок', () => {
+    expect(renderComponent).not.toThrow();
+  });
+
+  describe('проверка props', () => {
+    const label = 'label';
+    describe('проверка label', () => {
+      renderComponent({ label });
+      const tagBase = screen.getByTestId(testId);
+      expect(tagBase.textContent).toEqual(label);
+    });
+    describe('проверка size', () => {
+      const sizes = ['xs', 's', 'm', 'l'] as const;
+
+      sizes.forEach((size) => {
+        it(`присваивает класс для size=${size}`, () => {
+          renderComponent({ label, size });
+
+          const tagBase = screen.getByTestId(testId);
+
+          expect(tagBase).toHaveClass(cnTagBase({ size }));
+        });
+      });
+    });
+    describe('проверка group', () => {
+      const groups = [1, 2, 3, 4, 5, 6, 7, 8, 9] as const;
+
+      groups.forEach((group) => {
+        it(`присваивает класс для group=${group}`, () => {
+          renderComponent({ label, group });
+
+          const tagBase = screen.getByTestId(testId);
+
+          expect(tagBase).toHaveClass(cnTagBase({ group }));
+        });
+      });
+    });
+    describe('проверка view', () => {
+      const views = ['stroked', 'filled'] as const;
+
+      views.forEach((view) => {
+        it(`присваивает класс для view=${view}`, () => {
+          renderComponent({ label, view });
+
+          const tagBase = screen.getByTestId(testId);
+
+          expect(tagBase).toHaveClass(cnTagBase({ view }));
+        });
+      });
+    });
+    describe('проверка onCancel', () => {
+      it('отображает иконку на кнопке', () => {
+        const handleClick = jest.fn();
+        renderComponent({ label, onCancel: handleClick });
+        const tagBase = screen.getByTestId(testId);
+        const cancelButton = tagBase.querySelector(
+          `.${cnTagBase('CancelButton')}`,
+        ) as HTMLButtonElement;
+        expect(cancelButton.children[0]).toHaveClass(cnIcon());
+      });
+      it('кнопка закрытия срабатывает', () => {
+        const handleClick = jest.fn();
+        renderComponent({ label, onCancel: handleClick });
+        const tagBase = screen.getByTestId(testId);
+        const cancelButton = tagBase.querySelector(
+          `.${cnTagBase('CancelButton')}`,
+        ) as HTMLButtonElement;
+        fireEvent.click(cancelButton);
+        expect(handleClick).toHaveBeenCalledTimes(1);
+      });
+    });
+    describe('проверка onClick', () => {
+      it('кнопка срабатывает', () => {
+        const handleClick = jest.fn();
+        renderComponent({ label, onClick: handleClick });
+        const tagBase = screen.getByTestId(testId);
+        fireEvent.click(tagBase);
+        expect(handleClick).toHaveBeenCalledTimes(1);
+      });
+    });
+    describe('проверка as', () => {
+      const tags = ['a', 'div', 'span'] as const;
+
+      tags.forEach((el) => {
+        it(`должен рендериться как <${el}>`, () => {
+          renderComponent({ label, as: el });
+
+          const tagBase = screen.getByTestId(testId);
+
+          expect(tagBase.tagName).toEqual(el.toUpperCase());
+        });
+      });
+    });
+    describe('проверка className', () => {
+      const className = 'className';
+
+      it(`присваивает className`, () => {
+        renderComponent({ label, className });
+
+        const tagBase = screen.getByTestId(testId);
+
+        expect(tagBase).toHaveClass(className);
+      });
+    });
+    describe('проверка icon', () => {
+      it('отображает иконку', () => {
+        renderComponent({ label, icon: IconAttach });
+        const tagBase = screen.getByTestId(testId);
+        const icon = tagBase.querySelector(`.${cnTagBase('Icon')}`) as HTMLButtonElement;
+        expect(icon).toHaveClass('IconAttach');
+      });
+    });
+  });
+});

--- a/src/components/TagBase/TagBase.tsx
+++ b/src/components/TagBase/TagBase.tsx
@@ -1,0 +1,97 @@
+import './TagBase.css';
+
+import React from 'react';
+
+import { IconProps, IconPropSize } from '../../icons/Icon/Icon';
+import { IconClose } from '../../icons/IconClose/IconClose';
+import { cn } from '../../utils/bem';
+import { getSizeByMap } from '../../utils/getSizeByMap';
+import { ComponentWithAs, forwardRefWithAs } from '../../utils/types/PropsWithAsAttributes';
+
+export type TagBasePropSize = 'xs' | 's' | 'm' | 'l';
+export type TagBasePropGroup =
+  | 1
+  | 2
+  | 3
+  | 4
+  | 5
+  | 6
+  | 7
+  | 8
+  | 9
+  | '1'
+  | '2'
+  | '3'
+  | '4'
+  | '5'
+  | '6'
+  | '7'
+  | '8'
+  | '9';
+
+export type Props = {
+  size?: TagBasePropSize;
+  label: string;
+  children?: never;
+  view?: 'stroked' | 'filled';
+  group?: TagBasePropGroup;
+  onCancel?: React.MouseEventHandler<HTMLButtonElement>;
+  icon?: React.FC<IconProps>;
+  iconSize?: IconPropSize;
+};
+
+export const cnTagBase = cn('TagBase');
+
+const sizeMap: Record<TagBasePropSize, IconPropSize> = {
+  xs: 'xs',
+  s: 'xs',
+  m: 's',
+  l: 's',
+};
+
+export const TagBase: ComponentWithAs<Props> = forwardRefWithAs<Props>((props, ref) => {
+  const {
+    size = 'm',
+    as = 'div',
+    label,
+    className,
+    group,
+    view = 'stroked',
+    onCancel,
+    icon: Icon,
+    iconSize,
+    ...otherProps
+  } = props;
+
+  const Tag = as as string;
+  const withCancel = typeof onCancel === 'function';
+  const withIcon = !!Icon;
+  const IconCloseSize = getSizeByMap(sizeMap, size);
+  const IconSize = getSizeByMap(sizeMap, size, iconSize);
+
+  return (
+    <Tag
+      {...otherProps}
+      className={cnTagBase({ size, view, withCancel, withIcon, group }, [className])}
+      ref={ref}
+    >
+      {withCancel || Icon ? (
+        <>
+          {Icon && (
+            <span className={cnTagBase('IconWrapper')}>
+              <Icon size={IconSize} className={cnTagBase('Icon')} />
+            </span>
+          )}
+          <span className={cnTagBase('Label')}>{label}</span>
+          {withCancel && (
+            <button className={cnTagBase('CancelButton')} type="button" onClick={onCancel}>
+              <IconClose className={cnTagBase('CancelIcon')} size={IconCloseSize} />
+            </button>
+          )}
+        </>
+      ) : (
+        label
+      )}
+    </Tag>
+  );
+});

--- a/src/utils/useTimer.ts
+++ b/src/utils/useTimer.ts
@@ -38,7 +38,7 @@ export function useTimer(config?: Partial<Config>): Values {
     ...initialConfig,
     ...config,
   };
-  const intervalRef = useRef<NodeJS.Timeout | null>(null);
+  const intervalRef = useRef<number | null>(null);
   const pausedTimeRef = useRef<number | null>(null);
   const [shouldResetTime, setShouldResetTime] = useState(false);
   const [time, setTime] = useState(startTime);
@@ -82,7 +82,7 @@ export function useTimer(config?: Partial<Config>): Values {
   const createInterval = () => {
     setIsRunning(true);
 
-    intervalRef.current = setInterval(() => {
+    intervalRef.current = window.setInterval(() => {
       setTime((previousTime) => {
         const newTime =
           timerType === 'INCREMENTAL' ? previousTime + interval : previousTime - interval;


### PR DESCRIPTION
# Описание изменений
Добавил новый компонет Tag, создал его на TagBase.  TagBase - компонент который максимально умеет комбинировать модификаторы, Tag - в зависимости от "роли" наделяет необходимыми модификаторами TagBase и ограничевает их использование.

В зависимости от роли выводится нужный тип, прошу проверить тут получше, тут далеко не с первого раза удалось это сделать, может будут идеи как сделать лучше.

Сейчас названия ролей `'check' | 'button' | 'cancel'` думаю это не финальный вариант.

В TagBase есть стори, это сейчас для того чтобы просто посмотреть на компонент, как только все согласуем по компонету так уберу.

closes #219

## Чек-лист

- [x] PR: направлен в правильную ветку
- [x] PR: назначен исполнитель PR и указаны нужные лейблы
- [x] PR: проверен diff, ничего лишнего в PR не попало
- [x] PR: прилинкованы затронутые issue и связанные PR
- [x] PR: есть описание изменений
- [x] JS: нет варнингов и ошибок в консоли браузера
- [x] Тесты: новый функционал и исправленные баги покрыты тестами
- [x] Документация: отражены все изменения в API компонентов и описаны важные особенности реализации или использования
- [x] Сторибук: для компонентов написаны или обновлены stories
- [x] Верстка: используются [переменные](../src/components/Theme)
- [x] Верстка: проверена с разным количеством контента

## Опционально

- [ ] Доработки: заведены задачи для дальнейшей работы, если что-то решено не править в текущем пулл-реквесте
- [x] Коммиты: проименованы в соответствии с [правилами](../docs/commits-style.md)
