### PR TITLE
docs(StoryBook): change path FileField, export with createMetadata

### DIFF
--- a/src/components/File/__stories__/File.stories.tsx
+++ b/src/components/File/__stories__/File.stories.tsx
@@ -38,7 +38,6 @@ export const Gallery = FileIconsGallery;
 
 export default createMetadata({
   title: 'Components|/File',
-  component: Playground,
   parameters: {
     docs: {
       page: mdx,

--- a/src/components/FileField/__stories__/FileField.stories.tsx
+++ b/src/components/FileField/__stories__/FileField.stories.tsx
@@ -2,6 +2,7 @@ import './FileField.stories.css';
 
 import React, { useState } from 'react';
 
+import { createMetadata } from '../../../utils/storybook';
 import { Button } from '../../Button/Button';
 import { FileField, FileFieldProps } from '../FileField';
 
@@ -24,22 +25,21 @@ export function Playground() {
   const handleDelete = () => setValue(null);
 
   return (
-    <>
+    <div>
       <FileField onChange={handleChange} value={value} multiple>
         {({ onClick }) => <Button label="Выбрать файлы" onClick={onClick} />}
       </FileField>
       {renderFiles(value)}
       {value && value?.length > 0 && <Button label="Удалить файлы" onClick={handleDelete} />}
-    </>
+    </div>
   );
 }
 
-export default {
-  title: 'UI-KIT|/FileField',
-  component: Playground,
+export default createMetadata({
+  title: 'Components|/FileField',
   parameters: {
     docs: {
       page: mdx,
     },
   },
-};
+});

--- a/src/components/Informer/__stories__/Informer.stories.tsx
+++ b/src/components/Informer/__stories__/Informer.stories.tsx
@@ -31,7 +31,6 @@ export function Playground() {
 
 export default createMetadata({
   title: 'Components|/Informer',
-  component: Playground,
   parameters: {
     docs: {
       page: mdx,

--- a/src/components/Timer/__stories__/Timer.stories.tsx
+++ b/src/components/Timer/__stories__/Timer.stories.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { boolean, number, select } from '@storybook/addon-knobs';
 
+import { createMetadata } from '../../../utils/storybook';
 import { Timer } from '../Timer';
 
 import mdx from './Timer.mdx';
@@ -18,12 +19,11 @@ export function Playground() {
   return <Timer seconds={seconds} progress={progress} animation={animation} size={size} />;
 }
 
-export default {
+export default createMetadata({
   title: 'Components|/Timer',
-  component: Playground,
   parameters: {
     docs: {
       page: mdx,
     },
   },
-};
+});


### PR DESCRIPTION
closed  #284

## Описание изменений
* Поменял располоджение компонента FIleField
сейчас UiKit/FIleField
надо Components/FIleField
* не во всех стори был экспорт через createMetadata

## Чек-лист

- [x] PR: направлен в правильную ветку
- [x] PR: назначен исполнитель PR и указаны нужные лейблы
- [x] PR: проверен diff, ничего лишнего в PR не попало
- [x] PR: прилинкованы затронутые issue и связанные PR
- [x] PR: есть описание изменений
- [x] JS: нет варнингов и ошибок в консоли браузера
- [ ] Тесты: новый функционал и исправленные баги покрыты тестами
- [ ] Документация: отражены все изменения в API компонентов и описаны важные особенности реализации или использования
- [ ] Сторибук: для компонентов написаны или обновлены stories
- [ ] Верстка: используются [переменные](../src/components/Theme)
- [ ] Верстка: проверена с разным количеством контента

## Опционально

- [ ] Доработки: заведены задачи для дальнейшей работы, если что-то решено не править в текущем пулл-реквесте
- [x] Коммиты: проименованы в соответствии с [правилами](../docs/commits-style.md)
