### PR TITLE
fix(Table): even row's background wasn't changing on hover

### DIFF
--- a/src/components/Table/Table.css
+++ b/src/components/Table/Table.css
@@ -75,7 +75,7 @@
   }
 
   &-ContentCell {
-    .Table_isZebraStriped .Table-CellsRow:nth-child(even) &:not(.Table-ContentCell_isActive) {
+    .Table_isZebraStriped .Table-CellsRow:nth-child(even):not(:hover) &:not(&_isActive) {
       background-color: var(--color-bg-stripe);
     }
 


### PR DESCRIPTION
closes #303 

## Описание изменений

В полосатой таблице у строки с фоном не менялся фон при ховере

## Чек-лист

- [x] PR: направлен в правильную ветку
- [x] PR: назначен исполнитель PR и указаны нужные лейблы
- [x] PR: проверен diff, ничего лишнего в PR не попало
- [x] PR: прилинкованы затронутые issue и связанные PR
- [x] PR: есть описание изменений
- [ ] JS: нет варнингов и ошибок в консоли браузера
- [ ] Тесты: новый функционал и исправленные баги покрыты тестами
- [ ] Документация: отражены все изменения в API компонентов и описаны важные особенности реализации или использования
- [ ] Сторибук: для компонентов написаны или обновлены stories
- [ ] Верстка: используются [переменные](../src/components/Theme)
- [ ] Верстка: проверена с разным количеством контента

## Опционально

- [ ] Доработки: заведены задачи для дальнейшей работы, если что-то решено не править в текущем пулл-реквесте
- [x] Коммиты: проименованы в соответствии с [правилами](../docs/commits-style.md)
